### PR TITLE
Fix bug: post data is inflated if lastFetchedAt has not been recorded

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -90,8 +90,6 @@
   };
 
   const generateModel = async () => {
-    const npubChanged = npub !== npubInput;
-
     let pubkey = "";
     try {
       pubkey = getPubkey(npubInput);
@@ -99,10 +97,11 @@
       throw new Error("公開鍵のパースに失敗しました");
     }
 
-    // reset states if npub changed
-    let input = npubChanged ? "" : trainingData;
-    const currDataSize = npubChanged ? 0 : trainingDataSize;
-    const since = npubChanged ? undefined : lastFetchedAt;
+    const shouldResetStates = npub !== npubInput || lastFetchedAt === undefined;
+
+    let input = shouldResetStates ? "" : trainingData;
+    const currDataSize = shouldResetStates ? 0 : trainingDataSize;
+    const since = shouldResetStates ? undefined : lastFetchedAt;
 
     const fetchStartedAt = Math.floor(Date.now() / 1000);
     fetchedCount = 0;


### PR DESCRIPTION
#6 の修正以降、はじめて「マルコフモデルを生成」を行うと、以下のような意図しない挙動が発生することがわかりました。
- 投稿データに同じ投稿が2つずつ含まれた状態になる
- 表示上の投稿数が実際の数の約2倍で表示される

これは、「`lastFetchedAt`が未保存の場合」には全ての投稿を再取得するにもかかわらず、保存済みの状態`trainingData`,`trainingDataSize`をリセットすることなくデータを追加・加算してしまうのが原因です。

このPRでは、上記の問題を修正しました。

